### PR TITLE
Update README for modular architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,19 @@ Chain: `Pi → Module 1 DOUT → Module 2 DIN → Module 3 DIN → Module 4 DIN`
 
 ```
 display/
-├── font.py       5×7 bitmap font, column-major bitmasks for MAX7219
-├── display.py    Main display loop — scenes, transitions, file watching
-└── web.py        Flask web UI for editing messages
-install.sh        One-shot deploy script
+├── display.py        Main display loop — rendering, transitions, hardware push
+├── scheduler.py      Collects scenes from all modules; handles TTL and priority
+├── transitions.py    Pluggable transition registry (5 built-in + custom support)
+├── icons.py          Static icon bitmaps (column-major, same format as font.py)
+├── animations.py     Multi-frame animations (same format, list of frames)
+├── font.py           5×7 bitmap font, column-major bitmasks for MAX7219
+├── web.py            Flask web UI for editing messages
+├── config.json       Module enable/disable and per-module settings
+└── modules/
+    ├── base.py       DisplayModule base class
+    ├── textfile.py   Reads messages.txt; built-in, always active
+    └── …             Add new modules here (weather, stock, print status, …)
+install.sh            One-shot deploy script
 led-matrix-display.html   Browser pixel-accurate emulator (reference/preview)
 ```
 
@@ -45,12 +54,48 @@ Messages are driven by `/home/matt/display/messages.txt` — one line per entry.
 | `CLOCK` | Live HH:MM clock, colon blinks on odd seconds |
 | Short text (fits ≤32px wide) | Centred static frame, 3 seconds |
 | Long text | Scrolls right-to-left at 36 px/sec |
+| `[ICON:name] text` | Prefixes text with a static icon (see `icons.py` for names) |
+| `[ANIM:name] text` | Prefixes text with an animation (see `animations.py` for names) |
+| `[ANIM:name:fps] text` | Same, with explicit frame rate (default 4 fps) |
 
 The display watches the file for changes and reloads within ~2 seconds.
 
+**Available icons:** `thermometer`, `battery_ok`, `battery_low`, `wifi`, `snowflake`, `print_head`, `arrow_up`, `arrow_down`, `clock`, `ski`
+
+**Available animations:** `print_head`, `loading`, `stock_up`, `stock_down`, `live`
+
 ### Transitions
 
-Scenes cycle through five transitions in rotation: slide-left, wipe-right, curtain, rain, dissolve — all with cubic ease-in-out, matching the browser emulator exactly.
+Five built-in transitions cycle automatically: `slide-left`, `wipe-right`, `curtain`, `rain`, `dissolve` — all with cubic ease-in-out.
+
+Custom transitions can be registered from any module via `transitions.register(name, fn)`. A scene can also pin a specific transition with `scene['transition'] = 'name'`.
+
+### Module system
+
+Each data source is an independent module in `display/modules/`. Modules run independently — if one crashes or loses its data source, the rest keep displaying.
+
+**Key scene dict fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | str | `'static'`, `'scroll'`, or `'clock'` |
+| `text` | str | Text to display |
+| `duration` | float | Seconds to show (static/clock) |
+| `speed` | int | Scroll speed in px/sec (default 36) |
+| `icon` | str | Icon name to prefix |
+| `animation` | str | Animation name to prefix (takes precedence over icon) |
+| `ttl` | float | Seconds before scene is considered stale and dropped |
+| `priority` | int | Repeat count in rotation (default 1; higher = more frequent) |
+| `transition` | str | Override the auto-cycle transition for this scene |
+
+**Adding a module:**
+
+1. Create `display/modules/yourmodule.py` with a class `Module(DisplayModule)`
+2. Implement `get_scenes() -> list` — must never raise
+3. Enable it in `config.json`
+4. Redeploy with `install.sh`
+
+For modules that fetch data over the network, run the fetch in a daemon thread and cache results — `get_scenes()` should only read the cache so it never blocks the render loop.
 
 ## Deploy
 
@@ -89,6 +134,7 @@ journalctl -u display -f
 
 ## Home Assistant integration
 
-`display.py` has a commented-out stub at the bottom showing how to pull sensor
-data from the HA REST API and write it into `messages.txt`. Uncomment and set
-`HA_URL` / `HA_TOKEN` to enable.
+Create `display/modules/homeassistant.py` with a `Module` class that fetches
+sensor states from the HA REST API and returns them as scenes. Enable it in
+`config.json` with your `ha_url` and `ha_token`. Use a daemon thread for the
+HTTP fetch and cache results so the render loop is never blocked.


### PR DESCRIPTION
Reflects new file structure, module system, icon/animation tag syntax, transition plugin support, and scene dict reference. Replaces the HA stub note with guidance on writing a proper HA module.

https://claude.ai/code/session_01EWF78z934ssLZiRrjMrQoJ